### PR TITLE
Add Eito Kubota bio content with green theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,60 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>マイポートフォリオ</title>
+  <title>窪田 瑛仁 - ポートフォリオ</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <h1>マイポートフォリオ</h1>
+    <h1>Eito Kubota (窪田 瑛仁)</h1>
   </header>
 
   <section id="about">
     <h2>自己紹介</h2>
-    <p>これは私のポートフォリオサイトです。</p>
+    <h3>窪田 瑛仁</h3>
+    <p>所属：九州大学理学部数学科 学部4年</p>
+    <p>興味：解析的整数論、グラフ理論、サイエンスコミュニケーション</p>
+  </section>
+
+  <section id="activities">
+    <h2>活動記録</h2>
+    <table>
+      <tr>
+        <th>期間</th>
+        <th>内容</th>
+      </tr>
+      <tr>
+        <td>2023年01月～現在</td>
+        <td><a href="https://pr-platform.kyushu-u.ac.jp/pr-student/">九州大学広報課 広報学生スタッフ</a>取材班</td>
+      </tr>
+      <tr>
+        <td>2023年11月</td>
+        <td><a href="https://mathcafe.net/kumamoto-2023/">くまもと数学秋祭り2023</a>　ティーチングアシスタント</td>
+      </tr>
+      <tr>
+        <td>2024年3月～9月</td>
+        <td><a href="https://physicsmathematicsseminar.github.io/physmathseminar.github.io/camp/camp27.html">数物セミナー第27回合同合宿</a> 運営(数学庶務)</td>
+      </tr>
+      <tr>
+        <td>2024年12月～現在</td>
+        <td><a href="https://qrec.kyushu-u.ac.jp/">九州大学ロバート・ファン/アントレプレナーシップセンター(QREC)</a> 学生広報</td>
+      </tr>
+    </table>
+
+    <h3>広報課広報学生スタッフとしての活動</h3>
+    <p>2024年1月～2025年4月：取材班リーダー、Webサイトチームリーダーを担当</p>
+    <h4>公開記事</h4>
+    <ul>
+      <li><a href="https://pr-platform.kyushu-u.ac.jp/pr-student/activities/481">【九大生の１日】vol.1 理学部数学科3年生の1日</a></li>
+      <li><a href="https://pr-platform.kyushu-u.ac.jp/pr-student/activities/797">日本語学習支援に取り組む九大生を取材しました！</a></li>
+      <li><a href="https://www.kyushu-u.ac.jp/f/53478/kyudaikoho127_web.pdf">九大広報127号　躍動</a></li>
+    </ul>
+
+    <h3>QREC学生広報としての活動</h3>
+    <h4>公開記事</h4>
+    <ul>
+      <li><a href="https://note.com/qrec_pr/n/n05ba8aba90f9">「学生の価値を顕在化させる」ー九大芸能事務所の新しい価値創造のカタチ</a></li>
+    </ul>
   </section>
 
   <section id="contact">

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
-document.getElementById("contact-form").addEventListener("submit", function(event) {
+var form = document.getElementById("contact-form");
+form.addEventListener("submit", function(event) {
   event.preventDefault();
   var name = document.getElementById("name").value;
   alert("メッセージありがとうございます, " + name + "さん!");

--- a/style.css
+++ b/style.css
@@ -1,0 +1,58 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7fff0; /* 黄緑系の淡い背景 */
+  color: #333;
+  line-height: 1.6;
+}
+
+header {
+  background-color: #d0ff8a; /* 黄緑色 */
+  padding: 20px 0;
+  text-align: center;
+}
+
+h1 {
+  margin: 0;
+}
+
+section {
+  margin: 20px;
+}
+
+#activities table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1em;
+}
+
+#activities th,
+#activities td {
+  border: 1px solid #a3d977;
+  padding: 8px;
+  text-align: left;
+}
+
+#activities th {
+  background-color: #eaffc0;
+}
+
+#contact input,
+#contact textarea {
+  width: 100%;
+  padding: 8px;
+  margin: 5px 0;
+  box-sizing: border-box;
+}
+
+#contact button {
+  background-color: #a3d977;
+  color: #000;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+#contact button:hover {
+  background-color: #92c865;
+}
+


### PR DESCRIPTION
## Summary
- build a simple portfolio page for Eito Kubota in Japanese
- add biography and activity history
- apply a yellow‑green themed stylesheet
- keep basic contact form behavior

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6875c015db088321b5128e16bbc6a639